### PR TITLE
Remove preventDefault in .site-main-menu click event handling

### DIFF
--- a/js/pages-switcher.js
+++ b/js/pages-switcher.js
@@ -136,7 +136,6 @@ var PageTransitions = (function ($, options) {
 
         $(document)
             .on("click",".site-main-menu, #ajax-page-close-button", function (e) { // Hide Ajax Loaded Page on Navigation cleck and Close button
-                e.preventDefault();
                 hideContent();
                 location.hash = location.hash.split('/')[0];
             })


### PR DESCRIPTION
Click on `.site-main-menu` was prevented from triggering default behavior.